### PR TITLE
Upgrade to Keycloak 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.5-eclipse-temurin-17 AS build
+FROM maven:3.9.7-eclipse-temurin-21 AS build
 
 WORKDIR /home/app/src
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keycloak actions token
 
-This extension exposes a custom realm resource to manage action tokens in keycloak.
+This extension exposes a custom realm resource to manage action tokens in Keycloak.
 
 ## Build the example
 ```
@@ -9,9 +9,9 @@ mvn clean verify
 
 ## Deploy the example
 ### Wildfly
-Copy the `.jar` into the keycloak directory `standalone/deployments`
+Copy the `.jar` into the Keycloak directory `standalone/deployments`
 ### Quarkus
-Copy the `.jar` into the keycloak directory `providers`
+Copy the `.jar` into the Keycloak directory `providers`
 
 ## Routes
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,15 +7,16 @@
     <artifactId>actions-token</artifactId>
     <groupId>io.wiremind.keycloak.actionstoken</groupId>
     <packaging>jar</packaging>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <properties>
-        <java.version>17</java.version>
-        <keycloak.version>22.0.5</keycloak.version>
+        <java.version>21</java.version>
+        <keycloak.version>25.0.0</keycloak.version>
         <version.compiler.maven.plugin>3.8.1</version.compiler.maven.plugin>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <gson.version>2.10.1</gson.version>
+        <resteasy.version>3.12.0</resteasy.version>
     </properties>
 
     <dependencies>
@@ -41,6 +42,12 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
             <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+            <version>${resteasy.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
         <java.version>21</java.version>
         <keycloak.version>25.0.0</keycloak.version>
         <version.compiler.maven.plugin>3.8.1</version.compiler.maven.plugin>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <gson.version>2.10.1</gson.version>
         <resteasy.version>3.12.0</resteasy.version>
     </properties>

--- a/src/main/java/com/github/maxime1907/keycloak/actions/token/ActionsTokenResource.java
+++ b/src/main/java/com/github/maxime1907/keycloak/actions/token/ActionsTokenResource.java
@@ -20,7 +20,7 @@ import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.annotations.cache.NoCache;
+import org.jboss.resteasy.reactive.NoCache;
 import org.keycloak.TokenCategory;
 import org.keycloak.authentication.actiontoken.execactions.ExecuteActionsActionToken;
 import org.keycloak.common.util.Time;
@@ -76,7 +76,7 @@ public class ActionsTokenResource {
 
         if (!auth.getRealm().equals(realmManager.getKeycloakAdminstrationRealm())
                 && !auth.getRealm().equals(realm)) {
-            throw new org.keycloak.services.ForbiddenException();
+            throw new ForbiddenException();
         }
 
         realmAuth = AdminPermissions.evaluator(session, realm, auth);


### PR DESCRIPTION
- Upgrade Keycloak to version 25.0.0
- Upgrade to Java 21
- Add `quarkus-rest` to the POM file as the `resteasy-core-spi` was removed from Keycloak (see [commit](https://github.com/keycloak/keycloak/commit/35b9d8aa496bfe827e32adbd48e5eabb4ab182e7))
- Replace removed `org.keycloak.services.ForbiddenException()` with `ForbiddenException()`